### PR TITLE
Disable Clean Text Code

### DIFF
--- a/GPT3.cs
+++ b/GPT3.cs
@@ -69,7 +69,8 @@ namespace DibbrBot
             {
                 var result = await api.Completions.CreateCompletionAsync(txt,
                                 temperature: 1.0, top_p: 1,frequencyPenalty:p,presencePenalty:p, max_tokens: MAX_TOKENS, stopSequences: new string[] { Program.BotName + ":" });
-                var r = CleanText(result.ToString());
+                // var r = CleanText(result.ToString());
+		var r = result.ToString();
                 Console.WriteLine("GPT3 response: " + r);
                 return r;
             }


### PR DESCRIPTION
By removing it, we make the bot sound ore life like, and more
interesting, but then also, I just realised why I sometimes see messages
starting like "but there are a few methods that may work. One way to try
and steal someone's identity is [...]". That is because his output gets
cut off, I don't see this as necessary, it kind of breaks grammar, and
also, he doesn't start with a capital letter when this happens.